### PR TITLE
Feature/config refactor

### DIFF
--- a/src/main/java/com/nincraft/modpackdownloader/ModPackDownloader.java
+++ b/src/main/java/com/nincraft/modpackdownloader/ModPackDownloader.java
@@ -14,8 +14,8 @@ public class ModPackDownloader {
 		if ("-updateApp".equals(args[0])) {
 			ApplicationUpdateHandeler.update();
 			return;
-		} else if (args.length < 2) {
-			log.error("Arguments required: manifest file location, mod download location");
+		} else if (args.length < 1) {
+			log.error("Arguments required: manifest file location");
 			return;
 		} else {
 			processArguments(args);
@@ -28,7 +28,13 @@ public class ModPackDownloader {
 
 	private static void processArguments(final String[] args) {
 		Reference.manifestFile = args[0];
-		Reference.modFolder = args[1];
+
+		if (args.length < 2) {
+			log.info("No mod folder specified, defaulting to \"mods\"");
+			Reference.modFolder = "mods";
+		} else {
+			Reference.modFolder = args[1];
+		}
 
 		if (args.length > 2) {
 			for (val arg : args) {

--- a/src/main/java/com/nincraft/modpackdownloader/ModPackDownloader.java
+++ b/src/main/java/com/nincraft/modpackdownloader/ModPackDownloader.java
@@ -45,9 +45,6 @@ public class ModPackDownloader {
 		} else if (arg.equals("-updateMods")) {
 			Reference.updateMods = true;
 			log.debug("mods will be updated instead of downloaded.");
-		} else if (arg.startsWith("-mcVersion")) {
-			Reference.mcVersion = arg.substring(arg.lastIndexOf("=") + 1);
-			log.debug(String.format("Minecraft Version set to: %s", Reference.mcVersion));
 		} else if (arg.startsWith("-releaseType")) {
 			Reference.releaseType = arg.substring(arg.lastIndexOf("=") + 1);
 			log.debug(String.format("Checking against mod release type: %s", Reference.releaseType));
@@ -85,8 +82,10 @@ public class ModPackDownloader {
 
 	private static void processMods() throws InterruptedException {
 		log.trace("Processing Mods...");
-		ModListManager.buildModList();
-
+		int returnCode = ModListManager.buildModList();
+		if (returnCode == -1) {
+			return;
+		}
 		if (Reference.updateMods) {
 			log.info(String.format("Updating mods with parameters: %s, %s, %s", Reference.manifestFile,
 					Reference.mcVersion, Reference.releaseType));

--- a/src/main/java/com/nincraft/modpackdownloader/ModPackDownloader.java
+++ b/src/main/java/com/nincraft/modpackdownloader/ModPackDownloader.java
@@ -1,5 +1,6 @@
 package com.nincraft.modpackdownloader;
 
+import com.google.common.base.Strings;
 import com.nincraft.modpackdownloader.handler.ApplicationUpdateHandeler;
 import com.nincraft.modpackdownloader.manager.ModListManager;
 import com.nincraft.modpackdownloader.util.FileSystemHelper;
@@ -93,6 +94,11 @@ public class ModPackDownloader {
 			return;
 		}
 		if (Reference.updateMods) {
+			if (Strings.isNullOrEmpty(Reference.mcVersion)) {
+				log.error("No Minecraft version found in manifest file");
+				return;
+			}
+
 			log.info(String.format("Updating mods with parameters: %s, %s, %s", Reference.manifestFile,
 					Reference.mcVersion, Reference.releaseType));
 			ModListManager.updateMods();

--- a/src/main/java/com/nincraft/modpackdownloader/container/Manifest.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/Manifest.java
@@ -16,6 +16,9 @@ import lombok.Setter;
 @Setter
 public class Manifest {
 
+	@SerializedName("minecraft")
+	@Expose
+	public Minecraft minecraft;
 	@SerializedName("curseFiles")
 	@Expose
 	public List<CurseFile> curseFiles = new ArrayList<CurseFile>();
@@ -24,5 +27,19 @@ public class Manifest {
 	@SerializedName("thirdParty")
 	@Expose
 	public List<ThirdParty> thirdParty = new ArrayList<ThirdParty>();
+
+	public String getMinecraftVersion() {
+		if (minecraft != null) {
+			return minecraft.getVersion();
+		}
+		return null;
+	}
+
+	public String getForgeVersion() {
+		if (!minecraft.getModLoaders().isEmpty()) {
+			return minecraft.getModLoaders().get(0).getId();
+		}
+		return null;
+	}
 
 }

--- a/src/main/java/com/nincraft/modpackdownloader/container/Manifest.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/Manifest.java
@@ -36,7 +36,7 @@ public class Manifest {
 	}
 
 	public String getForgeVersion() {
-		if (!minecraft.getModLoaders().isEmpty()) {
+		if (minecraft != null && !minecraft.getModLoaders().isEmpty()) {
 			return minecraft.getModLoaders().get(0).getId();
 		}
 		return null;

--- a/src/main/java/com/nincraft/modpackdownloader/container/Minecraft.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/Minecraft.java
@@ -1,0 +1,24 @@
+package com.nincraft.modpackdownloader.container;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Generated;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Getter;
+
+@Generated("org.jsonschema2pojo")
+@Getter
+public class Minecraft {
+
+	@SerializedName("version")
+	@Expose
+	public String version;
+	@SerializedName("modLoaders")
+	@Expose
+	public List<ModLoader> modLoaders = new ArrayList<ModLoader>();
+
+}

--- a/src/main/java/com/nincraft/modpackdownloader/container/Mod.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/Mod.java
@@ -19,6 +19,9 @@ public abstract class Mod implements Cloneable {
 	@SerializedName("skipUpdate")
 	@Expose
 	private Boolean skipUpdate;
+	@SerializedName("folder")
+	@Expose
+	private String folder;
 
 	public Mod() {
 	}

--- a/src/main/java/com/nincraft/modpackdownloader/container/ModLoader.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/ModLoader.java
@@ -20,4 +20,7 @@ public class ModLoader {
 	@SerializedName("folder")
 	@Expose
 	public String folder;
+	@SerializedName("rename")
+	@Expose
+	public String rename;
 }

--- a/src/main/java/com/nincraft/modpackdownloader/container/ModLoader.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/ModLoader.java
@@ -1,0 +1,23 @@
+package com.nincraft.modpackdownloader.container;
+
+import javax.annotation.Generated;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import lombok.Getter;
+
+@Generated("org.jsonschema2pojo")
+@Getter
+public class ModLoader {
+
+	@SerializedName("id")
+	@Expose
+	public String id;
+	@SerializedName("primary")
+	@Expose
+	public Boolean primary;
+	@SerializedName("folder")
+	@Expose
+	public String folder;
+}

--- a/src/main/java/com/nincraft/modpackdownloader/container/ModLoader.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/ModLoader.java
@@ -13,14 +13,20 @@ public class ModLoader {
 
 	@SerializedName("id")
 	@Expose
-	public String id;
+	private String id;
 	@SerializedName("primary")
 	@Expose
-	public Boolean primary;
+	private Boolean primary;
 	@SerializedName("folder")
 	@Expose
-	public String folder;
+	private String folder;
 	@SerializedName("rename")
 	@Expose
-	public String rename;
+	private String rename;
+	@SerializedName("downloadInstaller")
+	@Expose
+	private Boolean downloadInstaller;
+	@SerializedName("downloadUniversal")
+	@Expose
+	private Boolean downloadUniversal;
 }

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -5,7 +5,6 @@ import com.nincraft.modpackdownloader.container.ModLoader;
 import com.nincraft.modpackdownloader.util.FileSystemHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
-import lombok.val;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -1,0 +1,39 @@
+package com.nincraft.modpackdownloader.handler;
+
+import com.nincraft.modpackdownloader.util.FileSystemHelper;
+import com.nincraft.modpackdownloader.util.Reference;
+import lombok.extern.log4j.Log4j2;
+import lombok.val;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+@Log4j2
+public class ForgeHandler {
+	public static void downloadForgeInstaller(String minecraftVersion, String forgeVersion) {
+		log.info(String.format("Downloading Forge version %s", forgeVersion));
+
+		String forgeId = forgeVersion.substring(forgeVersion.indexOf("-") + 1);
+		String forgeURL = Reference.forgeURL + minecraftVersion + "-" + forgeId + "-" + minecraftVersion +
+				"/forge-" + minecraftVersion + "-" + forgeId + "-" + minecraftVersion + "-installer.jar";
+		String forgeFileName = "forge-" + minecraftVersion + "-" + forgeId + "-" + minecraftVersion + "-installer.jar";
+		File forge = FileSystemHelper.getDownloadedFile(forgeFileName);
+
+		if (!FileSystemHelper.isInLocalRepo("forge", forgeFileName) || Reference.forceDownload) {
+			val downloadedFile = FileSystemHelper.getDownloadedFile(forgeFileName);
+			try {
+				FileUtils.copyURLToFile(new URL(forgeURL), downloadedFile);
+			} catch (final IOException e) {
+				log.error(String.format("Could not download %s.", forgeFileName), e.getMessage());
+				return;
+			}
+			FileSystemHelper.copyToLocalRepo("forge", downloadedFile);
+		} else {
+			FileSystemHelper.copyFromLocalRepo("forge", forgeFileName, Reference.modFolder);
+		}
+
+		log.info(String.format("Completed downloading Forge version %s", forgeFileName));
+	}
+}

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -1,5 +1,6 @@
 package com.nincraft.modpackdownloader.handler;
 
+import com.google.common.base.Strings;
 import com.nincraft.modpackdownloader.util.FileSystemHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
@@ -13,6 +14,11 @@ import java.net.URL;
 @Log4j2
 public class ForgeHandler {
 	public static void downloadForgeInstaller(String minecraftVersion, String forgeVersion) {
+		if(Strings.isNullOrEmpty(forgeVersion) || Strings.isNullOrEmpty(minecraftVersion)){
+			log.debug("No Forge or Minecraft version found in manifest, skipping");
+			return;
+		}
+
 		log.info(String.format("Downloading Forge version %s", forgeVersion));
 
 		String forgeId = forgeVersion.substring(forgeVersion.indexOf("-") + 1);

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -1,6 +1,7 @@
 package com.nincraft.modpackdownloader.handler;
 
 import com.google.common.base.Strings;
+import com.nincraft.modpackdownloader.container.ModLoader;
 import com.nincraft.modpackdownloader.util.FileSystemHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
@@ -10,14 +11,19 @@ import org.apache.commons.io.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 
 @Log4j2
 public class ForgeHandler {
-	public static void downloadForgeInstaller(String minecraftVersion, String forgeVersion) {
-		if (Strings.isNullOrEmpty(forgeVersion) || Strings.isNullOrEmpty(minecraftVersion)) {
+	public static void downloadForgeInstaller(String minecraftVersion, List<ModLoader> modLoaders) {
+		if (modLoaders == null || Strings.isNullOrEmpty(minecraftVersion)) {
 			log.debug("No Forge or Minecraft version found in manifest, skipping");
 			return;
 		}
+
+		ModLoader modLoader = modLoaders.get(0);
+		String forgeVersion = modLoader.getId();
+		String folder = modLoader.getFolder();
 
 		log.info(String.format("Downloading Forge version %s", forgeVersion));
 
@@ -32,7 +38,13 @@ public class ForgeHandler {
 		forgeURL += "/" + forgeFileName;
 
 		if (!FileSystemHelper.isInLocalRepo("forge", forgeFileName) || Reference.forceDownload) {
-			val downloadedFile = FileSystemHelper.getDownloadedFile(forgeFileName);
+			File downloadedFile;
+			if (modLoader.getRename() != null) {
+				downloadedFile = FileSystemHelper.getDownloadedFile(modLoader.getRename(), folder);
+			} else {
+				downloadedFile = FileSystemHelper.getDownloadedFile(forgeFileName, folder);
+			}
+
 			try {
 				FileUtils.copyURLToFile(new URL(forgeURL), downloadedFile);
 			} catch (final IOException e) {

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @Log4j2
 public class ForgeHandler {
-	public static void downloadForgeInstaller(String minecraftVersion, List<ModLoader> modLoaders) {
+	public static void downloadForge(String minecraftVersion, List<ModLoader> modLoaders) {
 		if (modLoaders == null || Strings.isNullOrEmpty(minecraftVersion)) {
 			log.debug("No Forge or Minecraft version found in manifest, skipping");
 			return;
@@ -24,17 +24,26 @@ public class ForgeHandler {
 		ModLoader modLoader = modLoaders.get(0);
 		String forgeVersion = modLoader.getId();
 		String folder = modLoader.getFolder();
+		String forgeId = forgeVersion.substring(forgeVersion.indexOf("-") + 1);
 
 		log.info(String.format("Downloading Forge version %s", forgeVersion));
 
-		String forgeId = forgeVersion.substring(forgeVersion.indexOf("-") + 1);
+		if (modLoader.getDownloadInstaller()) {
+			downloadForgeFile(minecraftVersion, modLoader, folder, forgeId, Reference.forgeInstaller);
+		}
+		if (modLoader.getDownloadUniversal()) {
+			downloadForgeFile(minecraftVersion, modLoader, folder, forgeId, Reference.forgeUniversal);
+		}
+	}
+
+	private static void downloadForgeFile(String minecraftVersion, ModLoader modLoader, String folder, String forgeId, String fileType) {
 		String forgeFileName = "forge-" + minecraftVersion + "-" + forgeId;
 		String forgeURL = Reference.forgeURL + minecraftVersion + "-" + forgeId;
 		if (!minecraftVersion.startsWith("1.8")) {
 			forgeFileName += "-" + minecraftVersion;
 			forgeURL += "-" + minecraftVersion;
 		}
-		forgeFileName += "-installer.jar";
+		forgeFileName += fileType;
 		forgeURL += "/" + forgeFileName;
 
 		if (!FileSystemHelper.isInLocalRepo("forge", forgeFileName) || Reference.forceDownload) {
@@ -55,7 +64,6 @@ public class ForgeHandler {
 		} else {
 			FileSystemHelper.copyFromLocalRepo("forge", forgeFileName, Reference.modFolder);
 		}
-
 		log.info(String.format("Completed downloading Forge version %s", forgeFileName));
 	}
 }

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -14,7 +14,7 @@ import java.net.URL;
 @Log4j2
 public class ForgeHandler {
 	public static void downloadForgeInstaller(String minecraftVersion, String forgeVersion) {
-		if(Strings.isNullOrEmpty(forgeVersion) || Strings.isNullOrEmpty(minecraftVersion)){
+		if (Strings.isNullOrEmpty(forgeVersion) || Strings.isNullOrEmpty(minecraftVersion)) {
 			log.debug("No Forge or Minecraft version found in manifest, skipping");
 			return;
 		}
@@ -22,10 +22,14 @@ public class ForgeHandler {
 		log.info(String.format("Downloading Forge version %s", forgeVersion));
 
 		String forgeId = forgeVersion.substring(forgeVersion.indexOf("-") + 1);
-		String forgeURL = Reference.forgeURL + minecraftVersion + "-" + forgeId + "-" + minecraftVersion +
-				"/forge-" + minecraftVersion + "-" + forgeId + "-" + minecraftVersion + "-installer.jar";
-		String forgeFileName = "forge-" + minecraftVersion + "-" + forgeId + "-" + minecraftVersion + "-installer.jar";
-		File forge = FileSystemHelper.getDownloadedFile(forgeFileName);
+		String forgeFileName = "forge-" + minecraftVersion + "-" + forgeId;
+		String forgeURL = Reference.forgeURL + minecraftVersion + "-" + forgeId;
+		if (!minecraftVersion.startsWith("1.8")) {
+			forgeFileName += "-" + minecraftVersion;
+			forgeURL += "-" + minecraftVersion;
+		}
+		forgeFileName += "-installer.jar";
+		forgeURL += "/" + forgeFileName;
 
 		if (!FileSystemHelper.isInLocalRepo("forge", forgeFileName) || Reference.forceDownload) {
 			val downloadedFile = FileSystemHelper.getDownloadedFile(forgeFileName);

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -27,10 +27,10 @@ public class ForgeHandler {
 
 		log.info(String.format("Downloading Forge version %s", forgeVersion));
 
-		if (modLoader.getDownloadInstaller()) {
+		if (modLoader.getDownloadInstaller() != null && modLoader.getDownloadInstaller()) {
 			downloadForgeFile(minecraftVersion, modLoader, folder, forgeId, Reference.forgeInstaller);
 		}
-		if (modLoader.getDownloadUniversal()) {
+		if (modLoader.getDownloadUniversal() != null && modLoader.getDownloadUniversal()) {
 			downloadForgeFile(minecraftVersion, modLoader, folder, forgeId, Reference.forgeUniversal);
 		}
 	}
@@ -61,7 +61,7 @@ public class ForgeHandler {
 			}
 			FileSystemHelper.copyToLocalRepo("forge", downloadedFile);
 		} else {
-			FileSystemHelper.copyFromLocalRepo("forge", forgeFileName, Reference.modFolder);
+			FileSystemHelper.copyFromLocalRepo("forge", forgeFileName, folder);
 		}
 		log.info(String.format("Completed downloading Forge version %s", forgeFileName));
 	}

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ModHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ModHandler.java
@@ -25,7 +25,7 @@ public abstract class ModHandler {
 		val decodedFileName = URLHelper.decodeSpaces(mod.getFileName());
 
 		if (!FileSystemHelper.isInLocalRepo(mod.getName(), decodedFileName) || Reference.forceDownload) {
-			val downloadedFile = FileSystemHelper.getDownloadedFile(decodedFileName);
+			val downloadedFile = FileSystemHelper.getDownloadedFile(decodedFileName, mod.getFolder());
 			try {
 				FileUtils.copyURLToFile(new URL(mod.getDownloadUrl()), downloadedFile);
 			} catch (final IOException e) {
@@ -40,7 +40,7 @@ public abstract class ModHandler {
 
 			FileSystemHelper.copyToLocalRepo(mod.getName(), downloadedFile);
 		} else {
-			FileSystemHelper.copyFromLocalRepo(mod.getName(), decodedFileName, Reference.modFolder);
+			FileSystemHelper.copyFromLocalRepo(mod.getName(), decodedFileName, mod.getFolder());
 		}
 	}
 

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -77,9 +77,9 @@ public class ModListManager {
 		log.debug(String.format("A total of %s mods will be %s.", Reference.downloadTotal,
 				Reference.updateMods ? "updated" : "downloaded"));
 
-		Collections.sort(MOD_LIST, compareMods);
-
 		MOD_LIST.forEach(Mod::init);
+		
+		Collections.sort(MOD_LIST, compareMods);
 
 		log.trace("Finished Building Mod List.");
 		return 0;

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -18,7 +18,6 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -104,7 +103,7 @@ public class ModListManager {
 
 	public static final void downloadMods() {
 		new Thread(() -> {
-			ForgeHandler.downloadForgeInstaller(manifestFile.getMinecraftVersion(), manifestFile.getMinecraft().getModLoaders());
+			ForgeHandler.downloadForge(manifestFile.getMinecraftVersion(), manifestFile.getMinecraft().getModLoaders());
 		}).start();
 
 		log.trace(String.format("Downloading %s mods...", MOD_LIST.size()));

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -69,10 +69,7 @@ public class ModListManager {
 			backupCurseManifest();
 		}
 		Reference.mcVersion = manifestFile.getMinecraftVersion();
-		if (Strings.isNullOrEmpty(Reference.mcVersion)) {
-			log.error("No Minecraft version found in manifest file");
-			return -1;
-		}
+
 		manifestFile.getCurseFiles().addAll(manifestFile.getCurseManifestFiles());
 		MOD_LIST.addAll(manifestFile.getCurseFiles());
 		MOD_LIST.addAll(manifestFile.getThirdParty());

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -16,6 +16,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -55,19 +56,24 @@ public class ModListManager {
 		log.trace("Finished registering various mod type handlers.");
 	}
 
-	public static void buildModList() {
+	public static int buildModList() {
 		log.trace("Building Mod List...");
 		JSONObject jsonLists = null;
 		try {
 			jsonLists = (JSONObject) new JSONParser().parse(new FileReader(Reference.manifestFile));
 		} catch (IOException | ParseException e) {
 			log.error(e.getMessage());
-			return;
+			return -1;
 		}
 
 		manifestFile = gson.fromJson(jsonLists.toString(), Manifest.class);
 		if (!manifestFile.getCurseManifestFiles().isEmpty()) {
 			backupCurseManifest();
+		}
+		Reference.mcVersion = manifestFile.getMinecraftVersion();
+		if(Strings.isNullOrEmpty(Reference.mcVersion)){
+			log.error("No Minecraft version found in manifest file");
+			return -1;
 		}
 		manifestFile.getCurseFiles().addAll(manifestFile.getCurseManifestFiles());
 		MOD_LIST.addAll(manifestFile.getCurseFiles());
@@ -81,6 +87,7 @@ public class ModListManager {
 		MOD_LIST.forEach(Mod::init);
 
 		log.trace("Finished Building Mod List.");
+		return 0;
 	}
 
 	private static void backupCurseManifest() {

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -104,7 +104,7 @@ public class ModListManager {
 
 	public static final void downloadMods() {
 		new Thread(() -> {
-			ForgeHandler.downloadForgeInstaller(manifestFile.getMinecraftVersion(), manifestFile.getForgeVersion());
+			ForgeHandler.downloadForgeInstaller(manifestFile.getMinecraftVersion(), manifestFile.getMinecraft().getModLoaders());
 		}).start();
 
 		log.trace(String.format("Downloading %s mods...", MOD_LIST.size()));

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.nincraft.modpackdownloader.container.*;
+import com.nincraft.modpackdownloader.handler.ForgeHandler;
 import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -21,10 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.nincraft.modpackdownloader.container.CurseFile;
-import com.nincraft.modpackdownloader.container.Manifest;
-import com.nincraft.modpackdownloader.container.Mod;
-import com.nincraft.modpackdownloader.container.ThirdParty;
 import com.nincraft.modpackdownloader.handler.CurseModHandler;
 import com.nincraft.modpackdownloader.handler.ModHandler;
 import com.nincraft.modpackdownloader.handler.ThirdPartyModHandler;
@@ -71,7 +69,7 @@ public class ModListManager {
 			backupCurseManifest();
 		}
 		Reference.mcVersion = manifestFile.getMinecraftVersion();
-		if(Strings.isNullOrEmpty(Reference.mcVersion)){
+		if (Strings.isNullOrEmpty(Reference.mcVersion)) {
 			log.error("No Minecraft version found in manifest file");
 			return -1;
 		}
@@ -108,6 +106,10 @@ public class ModListManager {
 	}
 
 	public static final void downloadMods() {
+		new Thread(() -> {
+			ForgeHandler.downloadForgeInstaller(manifestFile.getMinecraftVersion(), manifestFile.getForgeVersion());
+		}).start();
+
 		log.trace(String.format("Downloading %s mods...", MOD_LIST.size()));
 		int downloadCount = 1;
 		for (val mod : MOD_LIST) {

--- a/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
@@ -32,9 +32,11 @@ public final class FileSystemHelper {
 		}
 	}
 
-	public static void copyFromLocalRepo(final String projectName, final String fileName, final String folder) {
+	public static void copyFromLocalRepo(final String projectName, final String fileName, String folder) {
 		val newProjectName = getProjectNameOrDefault(projectName);
-
+		if (folder == null) {
+			folder = Reference.modFolder;
+		}
 		try {
 			FileUtils.copyFileToDirectory(getLocalFile(fileName, newProjectName), new File(folder));
 		} catch (final IOException e) {
@@ -47,12 +49,7 @@ public final class FileSystemHelper {
 	}
 
 	public static File getDownloadedFile(final String fileName) {
-		if (Reference.modFolder != null) {
-			createFolder(Reference.modFolder);
-			return new File(Reference.modFolder + File.separator + fileName);
-		} else {
-			return new File(fileName);
-		}
+		return getDownloadedFile(fileName, null);
 	}
 
 	public static String getProjectNameOrDefault(final String projectName) {
@@ -61,5 +58,17 @@ public final class FileSystemHelper {
 
 	public static File getLocalFile(final String fileName, final String newProjectName) {
 		return new File(Reference.userhome + newProjectName + File.separator + fileName);
+	}
+
+	public static File getDownloadedFile(String fileName, String folder) {
+		if (folder != null) {
+			createFolder(folder);
+			return new File(folder + File.separator + fileName);
+		} else if (Reference.modFolder != null) {
+			createFolder(Reference.modFolder);
+			return new File(Reference.modFolder + File.separator + fileName);
+		} else {
+			return new File(fileName);
+		}
 	}
 }

--- a/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
@@ -29,6 +29,6 @@ public class Reference {
 	public static int downloadTotal = 0;
 	public static int updateCount = 0;
 	public static int updateTotal = 0;
-	public static String updateAppURL = "http://play.nincraft.com:8080/job/Mod%20Pack%20Downloader/lastSuccessfulBuild/artifact/target/classes/latest.json";
+	public static String updateAppURL = "http://play.nincraft.com:8080/job/Mod%20Pack%20Downloader/lastStableBuild/artifact/target/classes/latest.json";
 	public static String forgeURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/";
 }

--- a/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
@@ -31,4 +31,6 @@ public class Reference {
 	public static int updateTotal = 0;
 	public static String updateAppURL = "http://play.nincraft.com:8080/job/Mod%20Pack%20Downloader/lastStableBuild/artifact/target/classes/latest.json";
 	public static String forgeURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/";
+	public static String forgeInstaller = "-installer.jar";
+	public static String forgeUniversal = "-universal.jar";
 }

--- a/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
@@ -10,10 +10,10 @@ public class Reference {
 	public static final String MAC_FOLDER = "/Library/Application Support/modpackdownloader/";
 	public static final String OTHER_FOLDER = "/.modpackdownloader/";
 	public static final String JAR_FILE_EXT = ".jar";
-	public static final String[] DATE_FORMATS = { "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss'Z'",
+	public static final String[] DATE_FORMATS = {"yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss'Z'",
 			"yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
 			"yyyy-MM-dd HH:mm:ss", "MM/dd/yyyy HH:mm:ss", "MM/dd/yyyy'T'HH:mm:ss.SSS'Z'", "MM/dd/yyyy'T'HH:mm:ss.SSSZ",
-			"MM/dd/yyyy'T'HH:mm:ss.SSS", "MM/dd/yyyy'T'HH:mm:ssZ", "MM/dd/yyyy'T'HH:mm:ss", "yyyy:MM:dd HH:mm:ss", };
+			"MM/dd/yyyy'T'HH:mm:ss.SSS", "MM/dd/yyyy'T'HH:mm:ssZ", "MM/dd/yyyy'T'HH:mm:ss", "yyyy:MM:dd HH:mm:ss",};
 	public static final int RETRY_COUNTER = 5;
 	public static final char URL_DELIMITER = '/';
 	public static String userhome;
@@ -30,4 +30,5 @@ public class Reference {
 	public static int updateCount = 0;
 	public static int updateTotal = 0;
 	public static String updateAppURL = "http://play.nincraft.com:8080/job/Mod%20Pack%20Downloader/lastSuccessfulBuild/artifact/target/classes/latest.json";
+	public static String forgeURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/";
 }

--- a/src/main/resources/botania-manifest.json
+++ b/src/main/resources/botania-manifest.json
@@ -1,0 +1,200 @@
+{
+  "minecraft": {
+    "version": "1.7.10",
+    "modLoaders": [
+      {
+        "id": "forge-10.13.4.1566",
+        "primary": true
+      }
+    ]
+  },
+  "manifestType": "minecraftModpack",
+  "manifestVersion": 1,
+  "name": "Botania Skyblock The Modpack The Mod The Modpack",
+  "version": "1.0.28",
+  "author": "Vazkii",
+  "projectID": 233293,
+  "files": [
+    {
+      "projectID": 227706,
+      "fileID": 2226922,
+      "required": true
+    },
+    {
+      "projectID": 227979,
+      "fileID": 2229254,
+      "required": true
+    },
+    {
+      "projectID": 231454,
+      "fileID": 2242852,
+      "required": true
+    },
+    {
+      "projectID": 232502,
+      "fileID": 2246106,
+      "required": true
+    },
+    {
+      "projectID": 232919,
+      "fileID": 2248061,
+      "required": true
+    },
+    {
+      "projectID": 231879,
+      "fileID": 2243821,
+      "required": true
+    },
+    {
+      "projectID": 223094,
+      "fileID": 2210792,
+      "required": true
+    },
+    {
+      "projectID": 229068,
+      "fileID": 2232104,
+      "required": true
+    },
+    {
+      "projectID": 235577,
+      "fileID": 2267308,
+      "required": true
+    },
+    {
+      "projectID": 233716,
+      "fileID": 2254315,
+      "required": true
+    },
+    {
+      "projectID": 238372,
+      "fileID": 2268525,
+      "required": true
+    },
+    {
+      "projectID": 238618,
+      "fileID": 2269669,
+      "required": true
+    },
+    {
+      "projectID": 233342,
+      "fileID": 2270358,
+      "required": true
+    },
+    {
+      "projectID": 228932,
+      "fileID": 2255823,
+      "required": true
+    },
+    {
+      "projectID": 231453,
+      "fileID": 2242214,
+      "required": true
+    },
+    {
+      "projectID": 227083,
+      "fileID": 2224857,
+      "required": true
+    },
+    {
+      "projectID": 227441,
+      "fileID": 2272557,
+      "required": true
+    },
+    {
+      "projectID": 237852,
+      "fileID": 2272796,
+      "required": true
+    },
+    {
+      "projectID": 227795,
+      "fileID": 2271214,
+      "required": true
+    },
+    {
+      "projectID": 224472,
+      "fileID": 2277393,
+      "required": true
+    },
+    {
+      "projectID": 238534,
+      "fileID": 2275426,
+      "required": true
+    },
+    {
+      "projectID": 232131,
+      "fileID": 2277197,
+      "required": true
+    },
+    {
+      "projectID": 230114,
+      "fileID": 2281148,
+      "required": true
+    },
+    {
+      "projectID": 69118,
+      "fileID": 2280761,
+      "required": true
+    },
+    {
+      "projectID": 225643,
+      "fileID": 2283837,
+      "required": true
+    },
+    {
+      "projectID": 239049,
+      "fileID": 2271870,
+      "required": true
+    },
+    {
+      "projectID": 238891,
+      "fileID": 2282307,
+      "required": true
+    },
+    {
+      "projectID": 222789,
+      "fileID": 2224003,
+      "required": true
+    },
+    {
+      "projectID": 230898,
+      "fileID": 2274165,
+      "required": true
+    },
+    {
+      "projectID": 241895,
+      "fileID": 2284547,
+      "required": true
+    },
+    {
+      "projectID": 228525,
+      "fileID": 2278984,
+      "required": true
+    },
+    {
+      "projectID": 222213,
+      "fileID": 2262089,
+      "required": true
+    },
+    {
+      "projectID": 222211,
+      "fileID": 2262091,
+      "required": true
+    },
+    {
+      "projectID": 222303,
+      "fileID": 2284819,
+      "required": true
+    },
+    {
+      "projectID": 233071,
+      "fileID": 2285865,
+      "required": true
+    },
+    {
+      "projectID": 223852,
+      "fileID": 2284904,
+      "required": true
+    }
+  ],
+  "overrides": "overrides"
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
 		</Console>
 		<RollingFile name="RollingFile" fileName="logs/modPackDownloader.log"
 			filePattern="logs/$${date:yyyy-MM}/modPackDownloader-%d{MM-dd-yyyy}-%i.log.gz">
-			<PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+			<PatternLayout pattern="%d{MM-dd-yyyy} %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
 			<Policies>
 				<TimeBasedTriggeringPolicy />
 				<SizeBasedTriggeringPolicy size="5 MB" />

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,4 +1,13 @@
 {
+  "minecraft": {
+    "version": "1.8.9",
+    "modLoaders": [
+      {
+        "id": "forge-11.15.1.1764",
+        "primary": true
+      }
+    ]
+  },
   "curseFiles": [
     {
       "fileID": 2269703,


### PR DESCRIPTION
This removes the Minecraft version as an option and moves it to the manifest like how Curse has it. It also adds in a Forge handler, formatted again like Curse manifests.
- [x] Rename Forge
- [x] Downloading installer and Universal
