### PR TITLE
Add JCommander for processing arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>zip4j</artifactId>
 			<version>1.3.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.beust</groupId>
+			<artifactId>jcommander</artifactId>
+			<version>1.48</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}-${project.version}+${build.number}</finalName>

--- a/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
@@ -3,6 +3,7 @@ package com.nincraft.modpackdownloader.handler;
 import com.google.common.base.Strings;
 import com.nincraft.modpackdownloader.container.CurseFile;
 import com.nincraft.modpackdownloader.container.Mod;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import com.nincraft.modpackdownloader.util.URLHelper;
@@ -99,7 +100,7 @@ public class CurseFileHandler extends ModHandler {
 			return;
 		}
 
-		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Reference.releaseType, curseFile, fileListJson);
+		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Arguments.releaseType, curseFile, fileListJson);
 		if (curseFile.getFileID().compareTo(newMod.getFileID()) < 0) {
 			log.info(String.format("Update found for %s.  Most recent version is %s.", curseFile.getName(),
 					newMod.getVersion()));
@@ -158,10 +159,10 @@ public class CurseFileHandler extends ModHandler {
 	}
 
 	private static boolean isMcVersion(String version) {
-		if ("*".equals(Reference.mcVersion)) {
+		if ("*".equals(Arguments.mcVersion)) {
 			return true;
 		} else {
-			return Reference.mcVersion.equals(version);
+			return Arguments.mcVersion.equals(version);
 		}
 	}
 

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -3,6 +3,7 @@ package com.nincraft.modpackdownloader.handler;
 import com.google.common.base.Strings;
 import com.nincraft.modpackdownloader.container.ModLoader;
 import com.nincraft.modpackdownloader.status.DownloadStatus;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
@@ -68,7 +69,7 @@ public class ForgeHandler {
 	}
 
 	public static List<ModLoader> updateForge(String minecraftVersion, List<ModLoader> modLoaders) {
-		if (!Reference.updateForge) {
+		if (!Arguments.updateForge) {
 			log.trace("Updating Forge disabled");
 			return modLoaders;
 		}

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -12,6 +12,7 @@ import com.nincraft.modpackdownloader.handler.CurseFileHandler;
 import com.nincraft.modpackdownloader.handler.ForgeHandler;
 import com.nincraft.modpackdownloader.handler.ModHandler;
 import com.nincraft.modpackdownloader.handler.ThirdPartyModHandler;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -62,23 +63,23 @@ public class ModListManager {
 		log.trace("Building Mod List...");
 		JSONObject jsonLists = null;
 		try {
-			jsonLists = (JSONObject) new JSONParser().parse(new FileReader(Reference.manifestFile));
+			jsonLists = (JSONObject) new JSONParser().parse(new FileReader(Arguments.manifestFile));
 		} catch (IOException | ParseException e) {
 			log.error(e);
 			return -1;
 		}
 
 		manifestFile = gson.fromJson(jsonLists.toString(), Manifest.class);
-		if (!manifestFile.getCurseFiles().isEmpty() && !Reference.updateCurseModPack) {
+		if (!manifestFile.getCurseFiles().isEmpty() && !Arguments.updateCurseModPack) {
 			backupCurseManifest();
 		}
-		Reference.mcVersion = manifestFile.getMinecraftVersion();
+		Arguments.mcVersion = manifestFile.getMinecraftVersion();
 
 		MOD_LIST.addAll(manifestFile.getCurseFiles());
 		MOD_LIST.addAll(manifestFile.getThirdParty());
 		Reference.updateTotal = Reference.downloadTotal = MOD_LIST.size();
 		log.debug(String.format("A total of %s mods will be %s.", Reference.downloadTotal,
-				Reference.updateMods ? "updated" : "downloaded"));
+				Arguments.updateMods ? "updated" : "downloaded"));
 
 		MOD_LIST.forEach(Mod::init);
 
@@ -90,7 +91,7 @@ public class ModListManager {
 
 	private static void backupCurseManifest() {
 		try {
-			FileUtils.copyFile(new File(Reference.manifestFile), new File(Reference.manifestFile + ".bak"), true);
+			FileUtils.copyFile(new File(Arguments.manifestFile), new File(Arguments.manifestFile + ".bak"), true);
 		} catch (IOException e) {
 			log.error("Could not backup Curse manifest file", e);
 		}
@@ -194,7 +195,7 @@ public class ModListManager {
 			removeBatchAdd();
 			Gson prettyGson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation()
 					.disableHtmlEscaping().create();
-			val file = new FileWriter(Reference.manifestFile);
+			val file = new FileWriter(Arguments.manifestFile);
 			file.write(prettyGson.toJson(manifestFile));
 			file.flush();
 			file.close();

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModPackManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModPackManager.java
@@ -5,6 +5,7 @@ import com.nincraft.modpackdownloader.container.CurseFile;
 import com.nincraft.modpackdownloader.container.Manifest;
 import com.nincraft.modpackdownloader.handler.CurseFileHandler;
 import com.nincraft.modpackdownloader.status.DownloadStatus;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
@@ -44,18 +45,18 @@ public class ModPackManager {
 		String modPackName = modPackIdName.substring(modPackIdName.indexOf('-') + 1);
 		CurseFile modPack = new CurseFile(modPackId, modPackName);
 		modPack.initModpack();
-		Reference.mcVersion = "*";
+		Arguments.mcVersion = "*";
 		CurseFileHandler.updateCurseFile(modPack);
 		if (!modPack.getFileName().contains(".zip")) {
 			modPack.setFileName(modPack.getFileName() + ".zip");
 		}
-		Reference.modFolder = ".";
+		Arguments.modFolder = ".";
 		if (DownloadStatus.SKIPPED.equals(DownloadHelper.downloadFile(modPack, false))) {
 			log.info(String.format("No new updates found for %s", modPack.getName()));
 			returnStatus = false;
 		}
-		Reference.modFolder = "mods";
-		File modsFolder = new File(Reference.modFolder);
+		Arguments.modFolder = "mods";
+		File modsFolder = new File(Arguments.modFolder);
 		File backupModsFolder = new File("backupmods");
 		try {
 			FileUtils.moveDirectory(modsFolder, backupModsFolder);
@@ -100,7 +101,7 @@ public class ModPackManager {
 			JSONObject currentJson = null;
 			JSONObject multiMCJson = null;
 			try {
-				currentJson = (JSONObject) new JSONParser().parse(new FileReader(Reference.manifestFile));
+				currentJson = (JSONObject) new JSONParser().parse(new FileReader(Arguments.manifestFile));
 				multiMCJson = (JSONObject) new JSONParser().parse(new FileReader("../patches/net.minecraftforge.json"));
 			} catch (IOException | ParseException e) {
 				log.error(e);

--- a/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
@@ -1,0 +1,26 @@
+package com.nincraft.modpackdownloader.util;
+
+import com.beust.jcommander.Parameter;
+
+public class Arguments {
+	@Parameter(names = {"-manifest"})
+	public static String manifestFile;
+	@Parameter(names = {"-modFolder", "-folder", "-mods"})
+	public static String modFolder;
+	@Parameter(names = {"-forceDownload"})
+	public static boolean forceDownload = false;
+	@Parameter(names = {"-updateMods"})
+	public static boolean updateMods;
+	@Parameter(names = {"-mcVersion"})
+	public static String mcVersion;
+	@Parameter(names = {"-releaseType"})
+	public static String releaseType;
+	@Parameter(names = {"-generateUrlTxt"})
+	public static boolean generateUrlTxt;
+	@Parameter(names = {"-updateForge"})
+	public static boolean updateForge;
+	@Parameter(names = {"-updateCurseModPack"})
+	public static boolean updateCurseModPack;
+	@Parameter(names = {"-updateApp"})
+	public static boolean updateApp;
+}

--- a/src/main/java/com/nincraft/modpackdownloader/util/DownloadHelper.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/DownloadHelper.java
@@ -45,7 +45,7 @@ public class DownloadHelper {
 			return DownloadStatus.SKIPPED;
 		}
 
-		if (!FileSystemHelper.isInLocalRepo(downloadableFile.getName(), decodedFileName) || Reference.forceDownload) {
+		if (!FileSystemHelper.isInLocalRepo(downloadableFile.getName(), decodedFileName) || Arguments.forceDownload) {
 			val downloadedFile = FileSystemHelper.getLocalFile(downloadableFile);
 			try {
 				FileUtils.copyURLToFile(new URL(downloadableFile.getDownloadUrl()), downloadedFile);

--- a/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
@@ -27,7 +27,7 @@ public final class FileSystemHelper {
 		val newProjectName = getProjectNameOrDefault(downloadableFile.getName());
 		String folder = downloadableFile.getFolder();
 		if (Strings.isNullOrEmpty(folder)) {
-			folder = Reference.modFolder;
+			folder = Arguments.modFolder;
 		}
 		try {
 			File downloadedFile = getDownloadedFile(fileName, folder);
@@ -68,9 +68,9 @@ public final class FileSystemHelper {
 		if (folder != null) {
 			createFolder(folder);
 			return new File(folder + File.separator + fileName);
-		} else if (Reference.modFolder != null) {
-			createFolder(Reference.modFolder);
-			return new File(Reference.modFolder + File.separator + fileName);
+		} else if (Arguments.modFolder != null) {
+			createFolder(Arguments.modFolder);
+			return new File(Arguments.modFolder + File.separator + fileName);
 		} else {
 			return new File(fileName);
 		}

--- a/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
@@ -21,13 +21,6 @@ public class Reference {
 	public static final String DEFAULT_MANIFEST_FILE = "manifest.json";
 	public static String userhome;
 	public static String os;
-	public static String manifestFile;
-	public static String modFolder;
-	public static boolean forceDownload = false;
-	public static boolean updateMods;
-	public static String mcVersion;
-	public static String releaseType;
-	public static boolean generateUrlTxt;
 	public static int downloadCount = 0;
 	public static int downloadTotal = 0;
 	public static int updateCount = 0;
@@ -36,8 +29,6 @@ public class Reference {
 	public static String forgeURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/";
 	public static String forgeInstaller = "-installer.jar";
 	public static String forgeUniversal = "-universal.jar";
-	public static boolean updateForge;
 	public static String forgeUpdateURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json";
 	public static String javaContentType = "application/java-archive";
-	public static boolean updateCurseModPack;
 }


### PR DESCRIPTION
This will change our batch file scripts a bit. Currently the manifest and folder are just the first and second argument. Now they have to have the -manifest and -folder option before them and they can be in any order. Release type is currently -releaseType=release and will now just be -releaseType release, no = needed.

Closes #35
