### PR TITLE
Feature/backup mc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.6</version>
+			<version>1.16.10</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>zip4j</artifactId>
 			<version>1.3.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.beust</groupId>
+			<artifactId>jcommander</artifactId>
+			<version>1.48</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}-${project.version}+${build.number}</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.nincraft</groupId>
 	<artifactId>ModPackDownloader</artifactId>
-	<version>0.2</version>
+	<version>0.3</version>
 	<name>Mod Pack Downloader</name>
 	<packaging>jar</packaging>
 	<properties>

--- a/src/main/java/com/nincraft/modpackdownloader/container/Mod.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/Mod.java
@@ -1,8 +1,5 @@
 package com.nincraft.modpackdownloader.container;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
-
 import lombok.Data;
 
 @Data

--- a/src/main/java/com/nincraft/modpackdownloader/container/ThirdParty.java
+++ b/src/main/java/com/nincraft/modpackdownloader/container/ThirdParty.java
@@ -1,16 +1,16 @@
 package com.nincraft.modpackdownloader.container;
 
-import javax.annotation.Generated;
-
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+
+import javax.annotation.Generated;
 
 @Generated("org.jsonschema2pojo")
 public class ThirdParty extends Mod {
 
 	@SerializedName("url")
 	@Expose
-	public String url;
+	private String url;
 
 	public String buildFileName() {
 		if (getDownloadUrl().contains(".jar")) {

--- a/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
@@ -3,6 +3,7 @@ package com.nincraft.modpackdownloader.handler;
 import com.google.common.base.Strings;
 import com.nincraft.modpackdownloader.container.CurseFile;
 import com.nincraft.modpackdownloader.container.Mod;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import com.nincraft.modpackdownloader.util.URLHelper;
@@ -99,7 +100,7 @@ public class CurseFileHandler extends ModHandler {
 			return;
 		}
 
-		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Reference.releaseType, curseFile, fileListJson);
+		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Arguments.releaseType, curseFile, fileListJson);
 		if (curseFile.getFileID().compareTo(newMod.getFileID()) < 0) {
 			log.info(String.format("Update found for %s.  Most recent version is %s.", curseFile.getName(),
 					newMod.getVersion()));
@@ -158,10 +159,10 @@ public class CurseFileHandler extends ModHandler {
 	}
 
 	private static boolean isMcVersion(String version) {
-		if ("*".equals(Reference.mcVersion)) {
+		if ("*".equals(Arguments.mcVersion)) {
 			return true;
 		} else {
-			return Reference.mcVersion.equals(version);
+			return Arguments.mcVersion.equals(version);
 		}
 	}
 

--- a/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
@@ -159,11 +159,7 @@ public class CurseFileHandler extends ModHandler {
 	}
 
 	private static boolean isMcVersion(String version) {
-		if ("*".equals(Arguments.mcVersion)) {
-			return true;
-		} else {
-			return Arguments.mcVersion.equals(version);
-		}
+		return "*".equals(Arguments.mcVersion) || Arguments.mcVersion.equals(version);
 	}
 
 	private static CurseFile checkFileId(CurseFile curseFile) {

--- a/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
@@ -9,6 +9,7 @@ import com.nincraft.modpackdownloader.util.Reference;
 import com.nincraft.modpackdownloader.util.URLHelper;
 import lombok.extern.log4j.Log4j2;
 import lombok.val;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -100,7 +101,7 @@ public class CurseFileHandler extends ModHandler {
 			return;
 		}
 
-		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Arguments.releaseType, curseFile, fileListJson);
+		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Arguments.releaseType, curseFile, fileListJson, null);
 		if (curseFile.getFileID().compareTo(newMod.getFileID()) < 0) {
 			log.info(String.format("Update found for %s.  Most recent version is %s.", curseFile.getName(),
 					newMod.getVersion()));
@@ -117,8 +118,13 @@ public class CurseFileHandler extends ModHandler {
 	}
 
 	private static CurseFile getLatestVersion(String releaseType,
-											  CurseFile curseFile, final JSONObject fileListJson) {
+											  CurseFile curseFile, final JSONObject fileListJson, String mcVersion) {
 		log.trace("Getting most recent available file...");
+		boolean backup = true;
+		if (Strings.isNullOrEmpty(mcVersion)) {
+			mcVersion = Arguments.mcVersion;
+			backup = false;
+		}
 		if (Strings.isNullOrEmpty(releaseType)) {
 			releaseType = "release";
 		}
@@ -126,7 +132,7 @@ public class CurseFileHandler extends ModHandler {
 		try {
 			newMod = (CurseFile) curseFile.clone();
 		} catch (CloneNotSupportedException e) {
-			log.warn("Couldn't clone existing mod reference, creating new one instead.");
+			log.debug("Couldn't clone existing mod reference, creating new one instead.");
 			newMod = new CurseFile();
 		}
 
@@ -135,7 +141,7 @@ public class CurseFileHandler extends ModHandler {
 		List<JSONObject> fileList = new ArrayList<JSONObject>(fileListJson.values());
 		List<Long> fileIds = new ArrayList<Long>();
 		for (JSONObject file : fileList) {
-			if (equalOrLessThan((String) file.get("type"), releaseType) && isMcVersion((String) file.get("version"))) {
+			if (equalOrLessThan((String) file.get("type"), releaseType) && isMcVersion((String) file.get("version"), mcVersion)) {
 				fileIds.add((Long) file.get("id"));
 			}
 		}
@@ -146,11 +152,23 @@ public class CurseFileHandler extends ModHandler {
 			newMod.setVersion((String) ((JSONObject) fileListJson.get(newMod.getFileID().toString())).get("name"));
 		}
 		if (!"alpha".equals(releaseType) && fileIds.isEmpty()) {
-			log.info(String.format("No files found for this Minecraft version, disabling download of %s", curseFile.getName()));
-			curseFile.setSkipDownload(true);
+			if (CollectionUtils.isEmpty(Arguments.backupVersions)) {
+				log.info(String.format("No files found for Minecraft %s, disabling download of %s", mcVersion, curseFile.getName()));
+				curseFile.setSkipDownload(true);
+			} else if (!backup) {
+				for (String backupVersion : Arguments.backupVersions) {
+					log.info(String.format("No files found for Minecraft %s, checking backup version %s", mcVersion, backupVersion));
+					newMod = getLatestVersion(releaseType, curseFile, fileListJson, backupVersion);
+					if (newMod.getFileID() != 0) {
+						curseFile.setSkipDownload(null);
+						log.info(String.format("Found update for %s in Minecraft %s", curseFile.getName(), backupVersion));
+						break;
+					}
+				}
+			}
 		}
 		if (BooleanUtils.isTrue(curseFile.getSkipUpdate()) && !fileIds.isEmpty()) {
-			log.info(String.format("Found files for this Minecraft version, enabling download of %s", curseFile.getName()));
+			log.info(String.format("Found files for Minecraft %s, enabling download of %s", mcVersion, curseFile.getName()));
 			curseFile.setSkipDownload(null);
 		}
 
@@ -158,8 +176,8 @@ public class CurseFileHandler extends ModHandler {
 		return newMod;
 	}
 
-	private static boolean isMcVersion(String version) {
-		return "*".equals(Arguments.mcVersion) || Arguments.mcVersion.equals(version);
+	private static boolean isMcVersion(String modVersion, String argVersion) {
+		return "*".equals(argVersion) || argVersion.equals(modVersion);
 	}
 
 	private static CurseFile checkFileId(CurseFile curseFile) {

--- a/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/ForgeHandler.java
@@ -3,6 +3,7 @@ package com.nincraft.modpackdownloader.handler;
 import com.google.common.base.Strings;
 import com.nincraft.modpackdownloader.container.ModLoader;
 import com.nincraft.modpackdownloader.status.DownloadStatus;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
@@ -68,7 +69,7 @@ public class ForgeHandler {
 	}
 
 	public static List<ModLoader> updateForge(String minecraftVersion, List<ModLoader> modLoaders) {
-		if (!Reference.updateForge) {
+		if (!Arguments.updateForge) {
 			log.trace("Updating Forge disabled");
 			return modLoaders;
 		}

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModListManager.java
@@ -12,6 +12,7 @@ import com.nincraft.modpackdownloader.handler.CurseFileHandler;
 import com.nincraft.modpackdownloader.handler.ForgeHandler;
 import com.nincraft.modpackdownloader.handler.ModHandler;
 import com.nincraft.modpackdownloader.handler.ThirdPartyModHandler;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -62,23 +63,23 @@ public class ModListManager {
 		log.trace("Building Mod List...");
 		JSONObject jsonLists = null;
 		try {
-			jsonLists = (JSONObject) new JSONParser().parse(new FileReader(Reference.manifestFile));
+			jsonLists = (JSONObject) new JSONParser().parse(new FileReader(Arguments.manifestFile));
 		} catch (IOException | ParseException e) {
 			log.error(e);
 			return -1;
 		}
 
 		manifestFile = gson.fromJson(jsonLists.toString(), Manifest.class);
-		if (!manifestFile.getCurseFiles().isEmpty() && !Reference.updateCurseModPack) {
+		if (!manifestFile.getCurseFiles().isEmpty() && !Arguments.updateCurseModPack) {
 			backupCurseManifest();
 		}
-		Reference.mcVersion = manifestFile.getMinecraftVersion();
+		Arguments.mcVersion = manifestFile.getMinecraftVersion();
 
 		MOD_LIST.addAll(manifestFile.getCurseFiles());
 		MOD_LIST.addAll(manifestFile.getThirdParty());
 		Reference.updateTotal = Reference.downloadTotal = MOD_LIST.size();
 		log.debug(String.format("A total of %s mods will be %s.", Reference.downloadTotal,
-				Reference.updateMods ? "updated" : "downloaded"));
+				Arguments.updateMods ? "updated" : "downloaded"));
 
 		MOD_LIST.forEach(Mod::init);
 
@@ -90,7 +91,7 @@ public class ModListManager {
 
 	private static void backupCurseManifest() {
 		try {
-			FileUtils.copyFile(new File(Reference.manifestFile), new File(Reference.manifestFile + ".bak"), true);
+			FileUtils.copyFile(new File(Arguments.manifestFile), new File(Arguments.manifestFile + ".bak"), true);
 		} catch (IOException e) {
 			log.error("Could not backup Curse manifest file", e);
 		}
@@ -194,7 +195,7 @@ public class ModListManager {
 			removeBatchAdd();
 			Gson prettyGson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation()
 					.disableHtmlEscaping().create();
-			val file = new FileWriter(Reference.manifestFile);
+			val file = new FileWriter(Arguments.manifestFile);
 			file.write(prettyGson.toJson(manifestFile));
 			file.flush();
 			file.close();

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModPackManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModPackManager.java
@@ -5,6 +5,7 @@ import com.nincraft.modpackdownloader.container.CurseFile;
 import com.nincraft.modpackdownloader.container.Manifest;
 import com.nincraft.modpackdownloader.handler.CurseFileHandler;
 import com.nincraft.modpackdownloader.status.DownloadStatus;
+import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
 import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
@@ -44,18 +45,18 @@ public class ModPackManager {
 		String modPackName = modPackIdName.substring(modPackIdName.indexOf('-') + 1);
 		CurseFile modPack = new CurseFile(modPackId, modPackName);
 		modPack.initModpack();
-		Reference.mcVersion = "*";
+		Arguments.mcVersion = "*";
 		CurseFileHandler.updateCurseFile(modPack);
 		if (!modPack.getFileName().contains(".zip")) {
 			modPack.setFileName(modPack.getFileName() + ".zip");
 		}
-		Reference.modFolder = ".";
+		Arguments.modFolder = ".";
 		if (DownloadStatus.SKIPPED.equals(DownloadHelper.downloadFile(modPack, false))) {
 			log.info(String.format("No new updates found for %s", modPack.getName()));
 			returnStatus = false;
 		}
-		Reference.modFolder = "mods";
-		File modsFolder = new File(Reference.modFolder);
+		Arguments.modFolder = "mods";
+		File modsFolder = new File(Arguments.modFolder);
 		File backupModsFolder = new File("backupmods");
 		try {
 			FileUtils.moveDirectory(modsFolder, backupModsFolder);
@@ -100,7 +101,7 @@ public class ModPackManager {
 			JSONObject currentJson = null;
 			JSONObject multiMCJson = null;
 			try {
-				currentJson = (JSONObject) new JSONParser().parse(new FileReader(Reference.manifestFile));
+				currentJson = (JSONObject) new JSONParser().parse(new FileReader(Arguments.manifestFile));
 				multiMCJson = (JSONObject) new JSONParser().parse(new FileReader("../patches/net.minecraftforge.json"));
 			} catch (IOException | ParseException e) {
 				log.error(e);

--- a/src/main/java/com/nincraft/modpackdownloader/manager/ModPackManager.java
+++ b/src/main/java/com/nincraft/modpackdownloader/manager/ModPackManager.java
@@ -7,7 +7,6 @@ import com.nincraft.modpackdownloader.handler.CurseFileHandler;
 import com.nincraft.modpackdownloader.status.DownloadStatus;
 import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
-import com.nincraft.modpackdownloader.util.Reference;
 import lombok.extern.log4j.Log4j2;
 import net.lingala.zip4j.core.ZipFile;
 import net.lingala.zip4j.exception.ZipException;

--- a/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
@@ -2,6 +2,8 @@ package com.nincraft.modpackdownloader.util;
 
 import com.beust.jcommander.Parameter;
 
+import java.util.List;
+
 public class Arguments {
 	@Parameter(names = {"-manifest"})
 	public static String manifestFile;
@@ -13,6 +15,8 @@ public class Arguments {
 	public static boolean updateMods;
 	@Parameter(names = {"-mcVersion"})
 	public static String mcVersion;
+	@Parameter(names = {"-backupVersions"})
+	public static List<String> backupVersions;
 	@Parameter(names = {"-releaseType"})
 	public static String releaseType;
 	@Parameter(names = {"-generateUrlTxt"})

--- a/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
@@ -1,0 +1,26 @@
+package com.nincraft.modpackdownloader.util;
+
+import com.beust.jcommander.Parameter;
+
+public class Arguments {
+	@Parameter(names = {"-manifest"})
+	public static String manifestFile;
+	@Parameter(names = {"-modFolder", "-folder", "-mods"})
+	public static String modFolder;
+	@Parameter(names = {"-forceDownload"})
+	public static boolean forceDownload = false;
+	@Parameter(names = {"-updateMods"})
+	public static boolean updateMods;
+	@Parameter(names = {"-mcVersion"})
+	public static String mcVersion;
+	@Parameter(names = {"-releaseType"})
+	public static String releaseType;
+	@Parameter(names = {"-generateUrlTxt"})
+	public static boolean generateUrlTxt;
+	@Parameter(names = {"-updateForge"})
+	public static boolean updateForge;
+	@Parameter(names = {"-updateCurseModPack"})
+	public static boolean updateCurseModPack;
+	@Parameter(names = {"-updateApp"})
+	public static boolean updateApp;
+}

--- a/src/main/java/com/nincraft/modpackdownloader/util/DownloadHelper.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/DownloadHelper.java
@@ -45,7 +45,7 @@ public class DownloadHelper {
 			return DownloadStatus.SKIPPED;
 		}
 
-		if (!FileSystemHelper.isInLocalRepo(downloadableFile.getName(), decodedFileName) || Reference.forceDownload) {
+		if (!FileSystemHelper.isInLocalRepo(downloadableFile.getName(), decodedFileName) || Arguments.forceDownload) {
 			val downloadedFile = FileSystemHelper.getLocalFile(downloadableFile);
 			try {
 				FileUtils.copyURLToFile(new URL(downloadableFile.getDownloadUrl()), downloadedFile);

--- a/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
@@ -27,7 +27,7 @@ public final class FileSystemHelper {
 		val newProjectName = getProjectNameOrDefault(downloadableFile.getName());
 		String folder = downloadableFile.getFolder();
 		if (Strings.isNullOrEmpty(folder)) {
-			folder = Reference.modFolder;
+			folder = Arguments.modFolder;
 		}
 		try {
 			File downloadedFile = getDownloadedFile(fileName, folder);
@@ -68,9 +68,9 @@ public final class FileSystemHelper {
 		if (folder != null) {
 			createFolder(folder);
 			return new File(folder + File.separator + fileName);
-		} else if (Reference.modFolder != null) {
-			createFolder(Reference.modFolder);
-			return new File(Reference.modFolder + File.separator + fileName);
+		} else if (Arguments.modFolder != null) {
+			createFolder(Arguments.modFolder);
+			return new File(Arguments.modFolder + File.separator + fileName);
 		} else {
 			return new File(fileName);
 		}

--- a/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
@@ -21,13 +21,6 @@ public class Reference {
 	public static final String DEFAULT_MANIFEST_FILE = "manifest.json";
 	public static String userhome;
 	public static String os;
-	public static String manifestFile;
-	public static String modFolder;
-	public static boolean forceDownload = false;
-	public static boolean updateMods;
-	public static String mcVersion;
-	public static String releaseType;
-	public static boolean generateUrlTxt;
 	public static int downloadCount = 0;
 	public static int downloadTotal = 0;
 	public static int updateCount = 0;
@@ -36,8 +29,6 @@ public class Reference {
 	public static String forgeURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/";
 	public static String forgeInstaller = "-installer.jar";
 	public static String forgeUniversal = "-universal.jar";
-	public static boolean updateForge;
 	public static String forgeUpdateURL = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json";
 	public static String javaContentType = "application/java-archive";
-	public static boolean updateCurseModPack;
 }

--- a/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Reference.java
@@ -12,10 +12,6 @@ public class Reference {
 	public static final String MAC_FOLDER = "/Library/Application Support/modpackdownloader/";
 	public static final String OTHER_FOLDER = "/.modpackdownloader/";
 	public static final String JAR_FILE_EXT = ".jar";
-	public static final String[] DATE_FORMATS = {"yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss'Z'",
-			"yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
-			"yyyy-MM-dd HH:mm:ss", "MM/dd/yyyy HH:mm:ss", "MM/dd/yyyy'T'HH:mm:ss.SSS'Z'", "MM/dd/yyyy'T'HH:mm:ss.SSSZ",
-			"MM/dd/yyyy'T'HH:mm:ss.SSS", "MM/dd/yyyy'T'HH:mm:ssZ", "MM/dd/yyyy'T'HH:mm:ss", "yyyy:MM:dd HH:mm:ss",};
 	public static final int RETRY_COUNTER = 5;
 	public static final char URL_DELIMITER = '/';
 	public static final String DEFAULT_MANIFEST_FILE = "manifest.json";


### PR DESCRIPTION
Adds -backupVersion argument. You can specify additional Minecraft versions to check mods for when updating. If no versions of a mod can be found for the main Minecraft version in the manifest, the backup versions will be checked in the order that they're put in as arguments. Once something is found, it will not look at the rest of the backup versions.
