### PR TITLE
Feature/backup mc version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.16.6</version>
+			<version>1.16.10</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
+++ b/src/main/java/com/nincraft/modpackdownloader/handler/CurseFileHandler.java
@@ -9,6 +9,7 @@ import com.nincraft.modpackdownloader.util.Reference;
 import com.nincraft.modpackdownloader.util.URLHelper;
 import lombok.extern.log4j.Log4j2;
 import lombok.val;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -100,7 +101,7 @@ public class CurseFileHandler extends ModHandler {
 			return;
 		}
 
-		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Arguments.releaseType, curseFile, fileListJson);
+		val newMod = getLatestVersion(curseFile.getReleaseType() != null ? curseFile.getReleaseType() : Arguments.releaseType, curseFile, fileListJson, null);
 		if (curseFile.getFileID().compareTo(newMod.getFileID()) < 0) {
 			log.info(String.format("Update found for %s.  Most recent version is %s.", curseFile.getName(),
 					newMod.getVersion()));
@@ -117,8 +118,13 @@ public class CurseFileHandler extends ModHandler {
 	}
 
 	private static CurseFile getLatestVersion(String releaseType,
-											  CurseFile curseFile, final JSONObject fileListJson) {
+											  CurseFile curseFile, final JSONObject fileListJson, String mcVersion) {
 		log.trace("Getting most recent available file...");
+		boolean backup = true;
+		if (Strings.isNullOrEmpty(mcVersion)) {
+			mcVersion = Arguments.mcVersion;
+			backup = false;
+		}
 		if (Strings.isNullOrEmpty(releaseType)) {
 			releaseType = "release";
 		}
@@ -126,7 +132,7 @@ public class CurseFileHandler extends ModHandler {
 		try {
 			newMod = (CurseFile) curseFile.clone();
 		} catch (CloneNotSupportedException e) {
-			log.warn("Couldn't clone existing mod reference, creating new one instead.");
+			log.debug("Couldn't clone existing mod reference, creating new one instead.");
 			newMod = new CurseFile();
 		}
 
@@ -135,7 +141,7 @@ public class CurseFileHandler extends ModHandler {
 		List<JSONObject> fileList = new ArrayList<JSONObject>(fileListJson.values());
 		List<Long> fileIds = new ArrayList<Long>();
 		for (JSONObject file : fileList) {
-			if (equalOrLessThan((String) file.get("type"), releaseType) && isMcVersion((String) file.get("version"))) {
+			if (equalOrLessThan((String) file.get("type"), releaseType) && isMcVersion((String) file.get("version"), mcVersion)) {
 				fileIds.add((Long) file.get("id"));
 			}
 		}
@@ -146,11 +152,23 @@ public class CurseFileHandler extends ModHandler {
 			newMod.setVersion((String) ((JSONObject) fileListJson.get(newMod.getFileID().toString())).get("name"));
 		}
 		if (!"alpha".equals(releaseType) && fileIds.isEmpty()) {
-			log.info(String.format("No files found for this Minecraft version, disabling download of %s", curseFile.getName()));
-			curseFile.setSkipDownload(true);
+			if (CollectionUtils.isEmpty(Arguments.backupVersions)) {
+				log.info(String.format("No files found for Minecraft %s, disabling download of %s", mcVersion, curseFile.getName()));
+				curseFile.setSkipDownload(true);
+			} else if (!backup) {
+				for (String backupVersion : Arguments.backupVersions) {
+					log.info(String.format("No files found for Minecraft %s, checking backup version %s", mcVersion, backupVersion));
+					newMod = getLatestVersion(releaseType, curseFile, fileListJson, backupVersion);
+					if (newMod.getFileID() != 0) {
+						curseFile.setSkipDownload(null);
+						log.info(String.format("Found update for %s in Minecraft %s", curseFile.getName(), backupVersion));
+						break;
+					}
+				}
+			}
 		}
 		if (BooleanUtils.isTrue(curseFile.getSkipUpdate()) && !fileIds.isEmpty()) {
-			log.info(String.format("Found files for this Minecraft version, enabling download of %s", curseFile.getName()));
+			log.info(String.format("Found files for Minecraft %s, enabling download of %s", mcVersion, curseFile.getName()));
 			curseFile.setSkipDownload(null);
 		}
 
@@ -158,8 +176,8 @@ public class CurseFileHandler extends ModHandler {
 		return newMod;
 	}
 
-	private static boolean isMcVersion(String version) {
-		return "*".equals(Arguments.mcVersion) || Arguments.mcVersion.equals(version);
+	private static boolean isMcVersion(String modVersion, String argVersion) {
+		return "*".equals(argVersion) || argVersion.equals(modVersion);
 	}
 
 	private static CurseFile checkFileId(CurseFile curseFile) {

--- a/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
+++ b/src/main/java/com/nincraft/modpackdownloader/util/Arguments.java
@@ -2,6 +2,8 @@ package com.nincraft.modpackdownloader.util;
 
 import com.beust.jcommander.Parameter;
 
+import java.util.List;
+
 public class Arguments {
 	@Parameter(names = {"-manifest"})
 	public static String manifestFile;
@@ -13,6 +15,8 @@ public class Arguments {
 	public static boolean updateMods;
 	@Parameter(names = {"-mcVersion"})
 	public static String mcVersion;
+	@Parameter(names = {"-backupVersions"})
+	public static List<String> backupVersions;
 	@Parameter(names = {"-releaseType"})
 	public static String releaseType;
 	@Parameter(names = {"-generateUrlTxt"})


### PR DESCRIPTION
Adds -backupVersion argument. You can specify additional Minecraft versions to check mods for when updating. If no versions of a mod can be found for the main Minecraft version in the manifest, the backup versions will be checked in the order that they're put in as arguments. Once something is found, it will not look at the rest of the backup versions.
