### PR TITLE
Implement MergeManifests Process

### DIFF
--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/container/Manifest.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/container/Manifest.java
@@ -16,19 +16,34 @@ public class Manifest {
 
 	@SerializedName("minecraft")
 	@Expose
-	public Minecraft minecraft;
+	private Minecraft minecraft;
+	@SerializedName("manifestType")
+	@Expose
+	private String manifestType;
+	@SerializedName("manifestVersion")
+	@Expose
+	private Integer manifestVersion;
+	@SerializedName("name")
+	@Expose
+	private String name;
+	@SerializedName("version")
+	@Expose
+	private String version;
+	@SerializedName("author")
+	@Expose
+	private String author;
 	@SerializedName("files")
 	@Expose
-	public List<CurseFile> curseFiles = new ArrayList<>();
+	private List<CurseFile> curseFiles = new ArrayList<>();
 	@SerializedName("thirdParty")
 	@Expose
-	public List<ThirdParty> thirdParty = new ArrayList<>();
+	private List<ThirdParty> thirdParty = new ArrayList<>();
 	@SerializedName("batchAddCurse")
 	@Expose
-	public List<String> batchAddCurse = new ArrayList<>();
+	private List<String> batchAddCurse = new ArrayList<>();
 	@SerializedName("overrides")
 	@Expose
-	public String overrides;
+	private String overrides;
 
 	public String getMinecraftVersion() {
 		if (minecraft != null) {

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
@@ -1,20 +1,62 @@
 package com.nincraft.modpackdownloader.processor;
 
+import com.google.common.collect.Sets;
+import com.nincraft.modpackdownloader.container.CurseFile;
 import com.nincraft.modpackdownloader.container.Manifest;
 import com.nincraft.modpackdownloader.util.Arguments;
 import com.nincraft.modpackdownloader.util.DownloadHelper;
+import com.nincraft.modpackdownloader.util.FileSystemHelper;
+import com.nincraft.modpackdownloader.util.ManifestHelper;
+import lombok.extern.log4j.Log4j2;
+import lombok.val;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
+@Log4j2
 public class MergeManifestsProcessor extends AbstractProcessor {
+	private final Set<CurseFile> curseModSet;
+	private final Manifest manifest;
+
 	public MergeManifestsProcessor(Arguments arguments, DownloadHelper downloadHelper) {
 		super(arguments, downloadHelper);
+
+		curseModSet = Sets.newHashSet();
+		manifest = new Manifest();
 	}
 
 	@Override
 	protected void init(Map<File, Manifest> manifestMap) {
-		//no-op
+		// no-op
 	}
 
+	@Override
+	public void process() throws InterruptedException {
+		for(val entry : manifestMap.entrySet()) {
+			process(entry);
+		}
+
+		manifest.getCurseFiles().addAll(curseModSet);
+		manifest.getCurseFiles().sort(modComparator);
+
+		manifest.setOverrides("overrides");
+
+		ManifestHelper.cleanupManifest(manifest);
+		FileSystemHelper.writeManifest(manifest, "target/manifest.json");
+	}
+
+	@Override
+	protected boolean process(Entry<File, Manifest> manifestEntry) {
+		val manifest = manifestEntry.getValue();
+
+		if (this.manifest.getMinecraft() == null && manifest.getMinecraft() != null) {
+			this.manifest.setMinecraft(manifest.getMinecraft());
+		}
+
+		curseModSet.addAll(manifest.getCurseFiles());
+
+		return true;
+	}
 }

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
@@ -18,13 +18,13 @@ import java.util.Set;
 @Log4j2
 public class MergeManifestsProcessor extends AbstractProcessor {
 	private final Set<CurseFile> curseModSet;
-	private final Manifest manifest;
+	private final Manifest newManifest;
 
 	public MergeManifestsProcessor(Arguments arguments, DownloadHelper downloadHelper) {
 		super(arguments, downloadHelper);
 
 		curseModSet = Sets.newHashSet();
-		manifest = new Manifest();
+		newManifest = new Manifest();
 	}
 
 	@Override
@@ -38,25 +38,50 @@ public class MergeManifestsProcessor extends AbstractProcessor {
 			process(entry);
 		}
 
-		manifest.getCurseFiles().addAll(curseModSet);
-		manifest.getCurseFiles().sort(modComparator);
+		newManifest.getCurseFiles().addAll(curseModSet);
+		newManifest.getCurseFiles().sort(modComparator);
 
-		manifest.setOverrides("overrides");
+		newManifest.setOverrides("overrides");
 
-		ManifestHelper.cleanupManifest(manifest);
-		FileSystemHelper.writeManifest(manifest, "target/manifest.json");
+		ManifestHelper.cleanupManifest(newManifest);
+		FileSystemHelper.writeManifest(newManifest, "target/newManifest.json");
 	}
 
 	@Override
 	protected boolean process(Entry<File, Manifest> manifestEntry) {
 		val manifest = manifestEntry.getValue();
 
-		if (this.manifest.getMinecraft() == null && manifest.getMinecraft() != null) {
-			this.manifest.setMinecraft(manifest.getMinecraft());
+		processManifestHeaders(manifest);
+
+		if (newManifest.getMinecraft() == null && manifest.getMinecraft() != null) {
+			newManifest.setMinecraft(manifest.getMinecraft());
 		}
 
 		curseModSet.addAll(manifest.getCurseFiles());
 
 		return true;
+	}
+
+	private void processManifestHeaders(Manifest manifest) {
+
+		if (newManifest.getAuthor() == null) {
+			newManifest.setAuthor(manifest.getAuthor());
+		}
+
+		if (newManifest.getManifestType() == null) {
+			newManifest.setManifestType(manifest.getManifestType());
+		}
+
+		if (newManifest.getMinecraftVersion() == null) {
+			newManifest.setManifestVersion(manifest.getManifestVersion());
+		}
+
+		if (newManifest.getName() == null) {
+			newManifest.setName(manifest.getName());
+		}
+
+		if (newManifest.getVersion() == null) {
+			newManifest.setVersion(manifest.getVersion());
+		}
 	}
 }

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
@@ -44,7 +44,7 @@ public class MergeManifestsProcessor extends AbstractProcessor {
 		newManifest.setOverrides("overrides");
 
 		ManifestHelper.cleanupManifest(newManifest);
-		FileSystemHelper.writeManifest(newManifest, "target/manifest.json");
+		FileSystemHelper.writeManifest(newManifest, "manifest.json");
 	}
 
 	@Override

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/MergeManifestsProcessor.java
@@ -44,7 +44,7 @@ public class MergeManifestsProcessor extends AbstractProcessor {
 		newManifest.setOverrides("overrides");
 
 		ManifestHelper.cleanupManifest(newManifest);
-		FileSystemHelper.writeManifest(newManifest, "target/newManifest.json");
+		FileSystemHelper.writeManifest(newManifest, "target/manifest.json");
 	}
 
 	@Override

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/UpdateModsProcessor.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/processor/UpdateModsProcessor.java
@@ -1,15 +1,11 @@
 package com.nincraft.modpackdownloader.processor;
 
-import com.google.gson.GsonBuilder;
 import com.nincraft.modpackdownloader.container.CurseFile;
 import com.nincraft.modpackdownloader.container.Manifest;
 import com.nincraft.modpackdownloader.container.Mod;
 import com.nincraft.modpackdownloader.handler.ForgeHandler;
 import com.nincraft.modpackdownloader.summary.UpdateCheckSummarizer;
-import com.nincraft.modpackdownloader.util.Arguments;
-import com.nincraft.modpackdownloader.util.DownloadHelper;
-import com.nincraft.modpackdownloader.util.Reference;
-import com.nincraft.modpackdownloader.util.URLHelper;
+import com.nincraft.modpackdownloader.util.*;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import lombok.val;
@@ -18,7 +14,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -105,35 +100,11 @@ public class UpdateModsProcessor extends AbstractProcessor {
 		manifest.getCurseFiles().sort(modComparator);
 		manifest.getThirdParty().sort(modComparator);
 
-		// Clean up Empty Lists
-		cleanupLists(manifest);
-
-		// Dump Manifest to file
-		val prettyGson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation()
-				.disableHtmlEscaping().create();
-		try (val fileWriter = new FileWriter(file)) {
-			fileWriter.write(prettyGson.toJson(manifest));
-		} catch (final IOException e) {
-			log.error(e);
-		}
+		ManifestHelper.cleanupModLists(manifest);
+		FileSystemHelper.writeManifest(manifest, file);
 	}
 
-	private void cleanupLists(final Manifest manifest) {
 
-		// Clean up Empty Lists
-		if (manifest.getCurseFiles().isEmpty()) {
-			manifest.setCurseFiles(null);
-		}
-		if (manifest.getThirdParty().isEmpty()) {
-			manifest.setThirdParty(null);
-		}
-		if (manifest.getMinecraft().getModLoaders().isEmpty()) {
-			manifest.getMinecraft().setModLoaders(null);
-		}
-
-		// Always Clean up Batch Add
-		manifest.setBatchAddCurse(null);
-	}
 
 	@Override
 	protected void init(final Map<File, Manifest> manifestMap) {

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/util/FileSystemHelper.java
@@ -1,13 +1,16 @@
 package com.nincraft.modpackdownloader.util;
 
 import com.google.common.base.Strings;
+import com.google.gson.GsonBuilder;
 import com.nincraft.modpackdownloader.container.DownloadableFile;
+import com.nincraft.modpackdownloader.container.Manifest;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import lombok.val;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 @Log4j2
@@ -78,6 +81,20 @@ public final class FileSystemHelper {
 			FileUtils.deleteDirectory(cache);
 		} catch (IOException e) {
 			log.error("Unable to clear cache", e);
+		}
+	}
+
+	public static void writeManifest(final Manifest manifest, final String filename) {
+		writeManifest(manifest, new File(filename));
+	}
+
+	public static void writeManifest(final Manifest manifest, final File file) {
+		val prettyGson = new GsonBuilder().setPrettyPrinting().excludeFieldsWithoutExposeAnnotation()
+				.disableHtmlEscaping().create();
+		try (val fileWriter = new FileWriter(file)) {
+			fileWriter.write(prettyGson.toJson(manifest));
+		} catch (final IOException e) {
+			log.error(e);
 		}
 	}
 }

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/util/ManifestHelper.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/util/ManifestHelper.java
@@ -1,0 +1,96 @@
+package com.nincraft.modpackdownloader.util;
+
+import com.nincraft.modpackdownloader.container.CurseFile;
+import com.nincraft.modpackdownloader.container.Manifest;
+import com.nincraft.modpackdownloader.container.Minecraft;
+import com.nincraft.modpackdownloader.container.ModLoader;
+import lombok.val;
+
+import java.util.List;
+
+public class ManifestHelper {
+
+	/**
+	 * Cleanup Mod Lists after an update
+	 * @param manifest
+	 */
+	public static void cleanupModLists(Manifest manifest) {
+
+		val minecraft = manifest.getMinecraft();
+		if (minecraft != null) {
+			val modLoaders = minecraft.getModLoaders();
+			if (modLoaders != null && modLoaders.isEmpty()) {
+				minecraft.setModLoaders(null);
+			}
+		}
+
+		if (manifest.getCurseFiles().isEmpty()) {
+			manifest.setCurseFiles(null);
+		}
+		if (manifest.getThirdParty().isEmpty()) {
+			manifest.setThirdParty(null);
+		}
+
+		// Always Clean up Batch Add
+		manifest.setBatchAddCurse(null);
+	}
+
+	/**
+	 * Clean up Merged Manifest for Curseforge deployment
+	 *
+	 * @param manifest
+	 */
+	public static void cleanupManifest(Manifest manifest) {
+		val minecraft = manifest.getMinecraft();
+
+		if (minecraft != null) {
+			cleanupMinecraft(minecraft);
+		}
+
+		val curseFiles = manifest.getCurseFiles();
+		if (curseFiles != null) {
+			cleanupCurseFiles(curseFiles);
+		}
+
+		manifest.setThirdParty(null);
+		manifest.setBatchAddCurse(null);
+	}
+
+	private static void cleanupMinecraft(Minecraft minecraft) {
+		val modLoaders = minecraft.getModLoaders();
+
+		if (modLoaders != null) {
+			if (modLoaders.isEmpty()) {
+				minecraft.setModLoaders(null);
+			} else {
+				cleanupModLoaders(modLoaders);
+			}
+		}
+	}
+
+	private static void cleanupModLoaders(List<ModLoader> modLoaders) {
+		for (val modLoader : modLoaders) {
+			cleanupModLoader(modLoader);
+		}
+	}
+
+	private static void cleanupModLoader(ModLoader modLoader) {
+		modLoader.setName(null);
+		modLoader.setFolder(null);
+		modLoader.setRelease(null);
+		modLoader.setDownloadInstaller(null);
+		modLoader.setDownloadUniversal(null);
+		modLoader.setRenameInstaller(null);
+		modLoader.setRenameUniversal(null);
+	}
+
+	private static void cleanupCurseFiles(List<CurseFile> curseFiles) {
+		for (val curseFile : curseFiles) {
+			cleanupCurseFile(curseFile);
+		}
+	}
+
+	private static void cleanupCurseFile(CurseFile curseFile) {
+		curseFile.setName(null);
+	}
+}

--- a/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/util/ManifestHelper.java
+++ b/modpackdownloader-core/src/main/java/com/nincraft/modpackdownloader/util/ManifestHelper.java
@@ -92,5 +92,7 @@ public class ManifestHelper {
 
 	private static void cleanupCurseFile(CurseFile curseFile) {
 		curseFile.setName(null);
+		curseFile.setSkipDownload(null);
+		curseFile.setSkipUpdate(null);
 	}
 }


### PR DESCRIPTION
Since both UpdateMods and MergeManifests use the GSON Writing process to output a Manifest object back to a file, I've extracted it out to the FileSystemHelper for now.  if we want to do more things like reading/writing our objects, we can make the relevant classes then.